### PR TITLE
Adding runtime configuration to ServiceConnect block (#3215)

### DIFF
--- a/agent/api/task/service_connect.go
+++ b/agent/api/task/service_connect.go
@@ -16,15 +16,22 @@ package task
 // ServiceConnectConfig represents the Service Connect configuration for a task.
 type ServiceConnectConfig struct {
 	ContainerName string               `json:"containerName"`
-	StatsConfig   StatsConfig          `json:"statsConfig"`
 	IngressConfig []IngressConfigEntry `json:"ingressConfig"`
 	EgressConfig  EgressConfig         `json:"egressConfig"`
 	DNSConfig     []DNSConfigEntry     `json:"dnsConfig"`
+
+	// Admin configuration for operating with AppNet Agent
+	RuntimeConfig RuntimeConfig `json:"runtimeConfig"`
 }
 
-// StatsConfig is the endpoint where SC stats can be retrieved from.
-type StatsConfig struct {
-	Path string `json:"path"`
+// RuntimeConfig contains the runtime information for administering AppNet Agent
+type RuntimeConfig struct {
+	// Host path for the administration socket
+	AdminSocketPath string `json:"adminSocketPath"`
+	// HTTP Path + Params to get statistical information
+	StatsRequest string `json:"statsRequest"`
+	// HTTP Path + Params to drain ServiceConnect connections
+	DrainRequest string `json:"drainRequest"`
 }
 
 // IngressConfigEntry is the ingress configuration for a given SC service.

--- a/agent/api/task/task.go
+++ b/agent/api/task/task.go
@@ -3177,3 +3177,17 @@ func (task *Task) PopulateServiceConnectContainerMappingEnvVar() error {
 	task.GetServiceConnectContainer().MergeEnvironmentVariables(envVars)
 	return nil
 }
+
+func (task *Task) PopulateServiceConnectRuntimeConfig(serviceConnectConfig RuntimeConfig) {
+	task.lock.Lock()
+	defer task.lock.Unlock()
+
+	task.ServiceConnectConfig.RuntimeConfig = serviceConnectConfig
+}
+
+func (task *Task) GetServiceConnectRuntimeConfig() RuntimeConfig {
+	task.lock.RLock()
+	defer task.lock.RUnlock()
+
+	return task.ServiceConnectConfig.RuntimeConfig
+}

--- a/agent/engine/service_connect/manager_linux_test.go
+++ b/agent/engine/service_connect/manager_linux_test.go
@@ -228,6 +228,8 @@ func TestAgentContainerModificationsForServiceConnect(t *testing.T) {
 		statusPathHostRoot:  filepath.Join(tempDir, "status"),
 		statusFileName:      "status_file_of_holiness",
 		statusENV:           "StAtUsGoEsHeRe",
+		adminStatsRequest:   "/give?stats",
+		adminDrainRequest:   "/do?drain",
 	}
 
 	for _, tc := range testcases {
@@ -239,6 +241,15 @@ func TestAgentContainerModificationsForServiceConnect(t *testing.T) {
 			}
 			assert.Equal(t, tc.expectedBinds, hostConfig.Binds)
 			assert.Equal(t, tc.expectedENV, tc.container.Environment)
+
 		})
 	}
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "relay_file_of_holiness"))
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.StatsRequest, "/give?stats")
+	assert.Equal(t, scTask.ServiceConnectConfig.RuntimeConfig.DrainRequest, "/do?drain")
+
+	config := scTask.GetServiceConnectRuntimeConfig()
+	assert.Equal(t, config.AdminSocketPath, fmt.Sprintf("%s/status/%s/%s", tempDir, scTask.GetID(), "relay_file_of_holiness"))
+	assert.Equal(t, config.StatsRequest, "/give?stats")
+	assert.Equal(t, config.DrainRequest, "/do?drain")
 }


### PR DESCRIPTION
Adding runtime configuration to ServiceConnect block

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

### Implementation details
<!-- How are the changes implemented? -->

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=30s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.
Once you open the pull request, there will be 14 automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it. You can
use `bot/test` label to rerun the automatic tests multiple times.
-->

New tests cover the changes: <!-- yes|no -->

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
